### PR TITLE
Add sudo python test and LTE integ test run on magma_deb VM

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -40,7 +40,7 @@
           <b-th colspan="1"><span class="sr-only">ID</span></b-th>
           <b-th variant="light" colspan="4">Metadata</b-th>
           <b-th variant="info" colspan="6">Builds</b-th>
-          <b-th variant="primary" colspan="5">Workers</b-th>
+          <b-th variant="primary" colspan="6">Workers</b-th>
         </b-tr>
       </template>
       <template #cell()="data">
@@ -160,6 +160,12 @@ export default {
             formatter: 'test_worker_formatter',
           },
           {
+            key: 'w_lte_integ_debian',
+            label: 'LTE INTEG DEBIAN',
+            type: 'pass_fail',
+            formatter: 'test_worker_formatter',
+          },
+          {
             key: 'w_feg_integ',
             label: 'FEG INTEG',
             type: 'pass_fail',
@@ -214,6 +220,10 @@ export default {
         if (dbObject.workers.lte_integ_test.reports) {
           lte_integ_report = (key in dbObject.workers.lte_integ_test.reports) ? dbObject.workers.lte_integ_test.reports[key] : {"verdict": "_not_present"};
         }
+        var lte_integ_debian_report = {};
+        if (dbObject.workers.make_debian_lte_integ_test.reports) {
+          lte_integ_debian_report = (key in dbObject.workers.make_debian_lte_integ_test.reports) ? dbObject.workers.make_debian_lte_integ_test.reports[key] : {"verdict": "_not_present"};
+        }
         var feg_integ_report = {};
         if (dbObject.workers.feg_integ_test.reports) {
           feg_integ_report = (key in dbObject.workers.feg_integ_test.reports) ? dbObject.workers.feg_integ_test.reports[key] : {"verdict": "_not_present"};
@@ -238,6 +248,7 @@ export default {
             w_sudo_python: sudo_python_report,
             w_wl5g: wl5g_report,
             w_lte_integ: lte_integ_report,
+            w_lte_integ_debian: lte_integ_debian_report,
             w_feg_integ: feg_integ_report,
             w_cwf_integ: cwf_integ_report,
           })

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -40,7 +40,7 @@
           <b-th colspan="1"><span class="sr-only">ID</span></b-th>
           <b-th variant="light" colspan="4">Metadata</b-th>
           <b-th variant="info" colspan="6">Builds</b-th>
-          <b-th variant="primary" colspan="4">Workers</b-th>
+          <b-th variant="primary" colspan="5">Workers</b-th>
         </b-tr>
       </template>
       <template #cell()="data">
@@ -148,6 +148,12 @@ export default {
             formatter: 'test_worker_formatter',
           },
           {
+            key: 'w_sudo_python',
+            label: 'SUDO PYTHON',
+            type: 'pass_fail',
+            formatter: 'test_worker_formatter',
+          },
+          {
             key: 'w_lte_integ',
             label: 'LTE INTEG',
             type: 'pass_fail',
@@ -196,6 +202,10 @@ export default {
         var branch_name = branch_path[branch_path.length - 1]
 
         // get reports
+        var sudo_python_report = {};
+        if (dbObject.workers.sudo_python_tests.reports) {
+          sudo_python_report = (key in dbObject.workers.sudo_python_tests.reports) ? dbObject.workers.sudo_python_tests.reports[key] : {"verdict": "_not_present"};
+        }
         var wl5g_report = {};
         if (dbObject.workers.wl_lab_5g.reports) {
           wl5g_report = (key in dbObject.workers.wl_lab_5g.reports) ? dbObject.workers.wl_lab_5g.reports[key] : {"verdict": "_not_present"};
@@ -225,6 +235,7 @@ export default {
             b_orc8r: build.orc8r,
             b_nms: build.nms,
             b_cwag: build.cwag,
+            w_sudo_python: sudo_python_report,
             w_wl5g: wl5g_report,
             w_lte_integ: lte_integ_report,
             w_feg_integ: feg_integ_report,

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -155,7 +155,7 @@ export default {
           },
           {
             key: 'w_lte_integ',
-            label: 'LTE INTEG',
+            label: 'LTE INTEG DEV',
             type: 'pass_fail',
             formatter: 'test_worker_formatter',
           },


### PR DESCRIPTION
- The sudo python tests are to be separated from the LTE integ tests to reduce execution time and should therefore be displayed separately.
- The LTE integ tests are run against the created Debian package and should also be displayed here.

Both workflows already publish their results to firebase.
Due to lack of credentials, this PR could not be tested locally. It would be great if someone with access could give feedback on this, if necessary.
Closes magma/magma#14159 and closes magma/magma#14160.