### PR TITLE
Switch from make- to bazel-based build

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -221,8 +221,8 @@ export default {
           lte_integ_report = (key in dbObject.workers.lte_integ_test.reports) ? dbObject.workers.lte_integ_test.reports[key] : {"verdict": "_not_present"};
         }
         var lte_integ_debian_report = {};
-        if (dbObject.workers.make_debian_lte_integ_test.reports) {
-          lte_integ_debian_report = (key in dbObject.workers.make_debian_lte_integ_test.reports) ? dbObject.workers.make_debian_lte_integ_test.reports[key] : {"verdict": "_not_present"};
+        if (dbObject.workers.debian_lte_integ_test.reports) {
+          lte_integ_debian_report = (key in dbObject.workers.debian_lte_integ_test.reports) ? dbObject.workers.debian_lte_integ_test.reports[key] : {"verdict": "_not_present"};
         }
         var feg_integ_report = {};
         if (dbObject.workers.feg_integ_test.reports) {


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

The switch from `make` to `bazel` as build tool needs to be reflected in the CI dashboard as well. Therefore, the dashboard should display the results of the LTE integ tests on the production-like Debian machine build with `bazel` instead of `make`. This requires 

1. The `bazel`-based workflow to publish the results to firebase.
2. Firebase to display these results and not the make-base ones.
3. The `make`-based workflow to not publish this anymore.

Since we operate across repositories here, three PRs seem the least invasive way to do this.

With this PR we display the results of the bazel-based tests.
Part of magma/magma#14180.