### PR TITLE
Remove unused ARM AGW column from dashboard

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -39,7 +39,7 @@
         <b-tr>
           <b-th colspan="1"><span class="sr-only">ID</span></b-th>
           <b-th variant="light" colspan="4">Metadata</b-th>
-          <b-th variant="info" colspan="6">Builds</b-th>
+          <b-th variant="info" colspan="5">Builds</b-th>
           <b-th variant="primary" colspan="6">Workers</b-th>
         </b-tr>
       </template>
@@ -108,12 +108,6 @@ export default {
           {
             key: 'b_agw',
             label: 'AGW',
-            type: 'pass_fail',
-            formatter: 'build_formatter',
-          },
-          {
-            key: 'b_arm_agw',
-            label: 'ARM AGW',
             type: 'pass_fail',
             formatter: 'build_formatter',
           },


### PR DESCRIPTION
This removes the "ARM AGW" column from the dashboard which is currently not used. If a workflow is added that publishes such results to Firebase, this can easily be reintroduced.

Tested via local deployment:

![Screenshot from 2023-02-27 10-34-42](https://user-images.githubusercontent.com/32741139/221527331-3267ff75-cce7-4e75-abf6-3fec20bf0d11.png)
